### PR TITLE
Post FHIR Resource to an open FHIR Endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "fhir-json",
 			"version": "0.0.1",
 			"dependencies": {
+				"cross-fetch": "^3.1.5",
 				"jsonc-parser": "^3.0.0"
 			},
 			"devDependencies": {
@@ -996,10 +997,16 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://paulmillr.com/funding/"
+				}
+			],
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -1089,6 +1096,14 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
 		},
+		"node_modules/cross-fetch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+			"dependencies": {
+				"node-fetch": "2.6.7"
+			}
+		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -1104,9 +1119,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -2336,32 +2351,32 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
-			"integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
+			"integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
 			"dev": true,
 			"dependencies": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.2.0",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
@@ -2383,26 +2398,6 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
-		},
-		"node_modules/mocha/node_modules/glob": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-			"dev": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
 		},
 		"node_modules/mocha/node_modules/has-flag": {
 			"version": "4.0.0",
@@ -2459,9 +2454,9 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
@@ -2481,6 +2476,25 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
+		},
+		"node_modules/node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/node-releases": {
 			"version": "1.1.76",
@@ -3313,6 +3327,11 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+		},
 		"node_modules/traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -3451,6 +3470,11 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+		},
 		"node_modules/webpack": {
 			"version": "5.54.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.54.0.tgz",
@@ -3585,6 +3609,15 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3616,9 +3649,9 @@
 			}
 		},
 		"node_modules/workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
 			"dev": true
 		},
 		"node_modules/wrap-ansi": {
@@ -4492,9 +4525,9 @@
 			}
 		},
 		"chokidar": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-			"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
 			"dev": true,
 			"requires": {
 				"anymatch": "~3.1.2",
@@ -4574,6 +4607,14 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
 		},
+		"cross-fetch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+			"requires": {
+				"node-fetch": "2.6.7"
+			}
+		},
 		"cross-spawn": {
 			"version": "7.0.3",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4586,9 +4627,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
@@ -5507,32 +5548,32 @@
 			}
 		},
 		"mocha": {
-			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
-			"integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.1.tgz",
+			"integrity": "sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==",
 			"dev": true,
 			"requires": {
 				"@ungap/promise-all-settled": "1.1.2",
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.5.2",
-				"debug": "4.3.2",
+				"chokidar": "3.5.3",
+				"debug": "4.3.3",
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.1.7",
+				"glob": "7.2.0",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.3",
-				"nanoid": "3.1.25",
+				"nanoid": "3.2.0",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
 				"which": "2.0.2",
-				"workerpool": "6.1.5",
+				"workerpool": "6.2.0",
 				"yargs": "16.2.0",
 				"yargs-parser": "20.2.4",
 				"yargs-unparser": "2.0.0"
@@ -5543,20 +5584,6 @@
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 					"dev": true
-				},
-				"glob": {
-					"version": "7.1.7",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
 				},
 				"has-flag": {
 					"version": "4.0.0",
@@ -5603,9 +5630,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
-			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -5619,6 +5646,14 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
+		},
+		"node-fetch": {
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+			"requires": {
+				"whatwg-url": "^5.0.0"
+			}
 		},
 		"node-releases": {
 			"version": "1.1.76",
@@ -6211,6 +6246,11 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+		},
 		"traverse": {
 			"version": "0.3.9",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -6314,6 +6354,11 @@
 				"graceful-fs": "^4.1.2"
 			}
 		},
+		"webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+		},
 		"webpack": {
 			"version": "5.54.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.54.0.tgz",
@@ -6399,6 +6444,15 @@
 			"integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
 			"dev": true
 		},
+		"whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"requires": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6421,9 +6475,9 @@
 			"dev": true
 		},
 		"workerpool": {
-			"version": "6.1.5",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
-			"integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.0.tgz",
+			"integrity": "sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==",
 			"dev": true
 		},
 		"wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,18 @@
 	],
 	"main": "./dist/extension.js",
 	"contributes": {
+		"commands": [ 
+			{ "command": "fhir.post", "title": "Post FHIR Resource" }
+		],
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "fhir.post",
+					"when": "explorerViewletVisible",
+					"group": "fhirServer"
+				}
+			]
+		},
 		"jsonValidation": [
 			{
 				"fileMatch": "*.json",
@@ -39,7 +51,8 @@
 		"test": "node ./out/test/runTest.js"
 	},
 	"dependencies": {
-		"jsonc-parser": "^3.0.0"
+		"jsonc-parser": "^3.0.0",
+		"cross-fetch": "^3.1.5"
 	},
 	"devDependencies": {
 		"@types/vscode": "^1.60.0",

--- a/package.json
+++ b/package.json
@@ -22,16 +22,18 @@
 	"main": "./dist/extension.js",
 	"contributes": {
 		"commands": [ 
-			{ "command": "fhir.post", "title": "Post FHIR Resource" }
+			{ "command": "fhir.put", "title": "Create/Update FHIR Resource" }
 		],
 		"menus": {
-			"explorer/context": [
-				{
-					"command": "fhir.post",
-					"when": "explorerViewletVisible",
-					"group": "fhirServer"
-				}
-			]
+			"explorer/context": [{
+				"command": "fhir.put",
+				"when": "explorerViewletVisible",
+				"group": "fhirServer"
+			}],
+			"editor/context": [{
+				"command": "fhir.put",
+				"group": "fhirServer"
+			}]
 		},
 		"jsonValidation": [
 			{

--- a/package.json
+++ b/package.json
@@ -38,7 +38,17 @@
 				"fileMatch": "*.json",
 				"url": "fhirjson://schema"
 			}
-		]
+		],
+		"configuration": {
+			"title": "FHIR Server URL",
+			"properties": {
+				"fhir.serverUrl": {
+					"type":"string",
+					"default": null,
+					"description": "Specifies the FHIR Server to send resources to from the explorer context menu"
+				}
+			}
+		} 
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run package",

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,6 +1,6 @@
 import { Diagnostic, DiagnosticCollection, DiagnosticSeverity, ExtensionContext, languages, Range, TextDocument, window, workspace } from "vscode";
 import path = require('path');
-import { findNodeAtLocation, getLocation, getNodeValue, Node, parseTree } from 'jsonc-parser';
+import { findNodeAtLocation, getNodeValue, parseTree } from 'jsonc-parser';
 
 function refreshDiagnostics(doc: TextDocument, fhirJsonDiagnostics: DiagnosticCollection): void {
 	if (doc.languageId !== "json") {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ export function activate(context: ExtensionContext) {
 	subscribeToChangesForDiagnostics(context);
 
 	// Register actions to send FHIR resources to a server
-	commands.registerCommand('fhir.post', uri => postResource(uri));
+	commands.registerCommand('fhir.put', uri => postResource(uri));
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,9 @@
 
-import { workspace, ExtensionContext, languages } from 'vscode';
+import { workspace, ExtensionContext, languages, commands, Uri } from 'vscode';
 import { subscribeToDocumentChanges as subscribeToChangesForDiagnostics } from './diagnostics';
 import { FHIRJsonCompletionProvider } from './fhirJsonCompletionProvider';
 import { FHIRJsonSchemaProvider } from './fhirJsonSchemaProvider';
+import { postResource } from './server-actions/postResource';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -24,6 +25,9 @@ export function activate(context: ExtensionContext) {
 
 	// Register for document changes to publish diagnostics
 	subscribeToChangesForDiagnostics(context);
+
+	// Register actions to send FHIR resources to a server
+	commands.registerCommand('fhir.post', uri => postResource(uri));
 }
 
 // this method is called when your extension is deactivated

--- a/src/server-actions/postResource.ts
+++ b/src/server-actions/postResource.ts
@@ -2,7 +2,7 @@ import { window ,workspace, Uri } from "vscode";
 import { readFileSync } from 'fs';
 import fetch from "cross-fetch";
 
-const displayMessage = (message: string, error?: boolean ): void => {
+const displayMessage = (message: string, error?: boolean): void => {
   const { showInformationMessage, showErrorMessage } = window;
   console.log(message);
   error ? showErrorMessage(message) : showInformationMessage(message);
@@ -38,6 +38,6 @@ export const postResource = async (uri: Uri) => {
     body: JSON.stringify(fhirObject)
   });
 
-  response.ok ? displayMessage(`The resource was posted to ${fhirServerUrl} and the server responded with ${response.status}: ${response.statusText}`) :
-    displayMessage(`The resource was rejected by ${fhirServerUrl} and the server responded with ${response.status}: ${response.statusText}`, true);
+  const responseBody = JSON.stringify(await response.json());
+  response.ok ? displayMessage(responseBody) : displayMessage(responseBody, true);
 };

--- a/src/server-actions/postResource.ts
+++ b/src/server-actions/postResource.ts
@@ -1,0 +1,30 @@
+import { window, Uri } from "vscode";
+import { readFileSync } from 'fs';
+import fetch from "cross-fetch";
+
+const buildFhirServerUrl = async (resourceType: string, id: string): Promise<string> => {
+  const baseUrl = await window.showInputBox({
+    placeHolder: "FHIR Base URL",
+    prompt: "Please provide a open FHIR endpoint"
+  });
+  // const baseUrl = 'http://localhost:8080/fhir';
+  return `${baseUrl}/${resourceType}/${id}`;
+};
+
+export const postResource = async (uri: Uri) => {
+  // @ts-ignore JSON.parse accepts both a buffer and string but TS throws an error 
+  const fhirObject = JSON.parse(readFileSync(uri.fsPath));
+  const { id, resourceType } = fhirObject;
+
+  const fhirServerUrl: string = await buildFhirServerUrl(resourceType, id);
+  const { showInformationMessage, showErrorMessage } = window;
+
+  const response = await fetch(fhirServerUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json+fhir' },
+    body: JSON.stringify(fhirObject)
+  });
+
+  response.ok ? showInformationMessage(`The resource was posted to ${fhirServerUrl} and the server responded with ${response.status}: ${response.statusText}`) :
+    showErrorMessage(`The resource was rejected by ${fhirServerUrl} and the server responded with ${response.status}: ${response.statusText}`);
+};

--- a/src/server-actions/postResource.ts
+++ b/src/server-actions/postResource.ts
@@ -3,9 +3,8 @@ import { readFileSync } from 'fs';
 import fetch from "cross-fetch";
 
 const displayMessage = (message: string, error?: boolean): void => {
-  const { showInformationMessage, showErrorMessage } = window;
   console.log(message);
-  error ? showErrorMessage(message) : showInformationMessage(message);
+  error ? window.showErrorMessage(message) : window.showInformationMessage(message);
 };
 
 const buildFhirUrl = async (resourceType: string, id: string): Promise<string> => {
@@ -29,7 +28,6 @@ export const postResource = async (uri: Uri) => {
   // @ts-ignore JSON.parse accepts both a buffer and string but TS throws an error 
   const fhirObject = JSON.parse(readFileSync(uri.fsPath));
   const { id, resourceType } = fhirObject;
-
   const fhirServerUrl: string = await buildFhirUrl(resourceType, id);
 
   const response = await fetch(fhirServerUrl, {


### PR DESCRIPTION
Implements the ability to post a valid FHIR resource to an open endpoint of a FHIR server. Simply alt-click on the file in the explorer, and chose 'Post FHIR Resource'. It should be noted that only one resource at a time is currently supported, and that the HTTP action is actually a `PUT` operation, in order to maintain the ID of the resource when querying the FHIR server. 

If no FHIR server URL is set globally, the user is prompted to provide one, which can be changed in the VSCode settings later on

Issue #7 